### PR TITLE
Multiple GET endpoints

### DIFF
--- a/task-services/src/main/java/com/taat/taskservices/controllers/TaskController.java
+++ b/task-services/src/main/java/com/taat/taskservices/controllers/TaskController.java
@@ -3,6 +3,9 @@ package com.taat.taskservices.controllers;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -30,9 +33,23 @@ public class TaskController {
   @Autowired
   TaskService taskService;
 
-  @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+  @GetMapping(path = "/all", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Flux<Task>> getTasks() {
-    Flux<Task> tasks = taskService.getPrioritizedTasks();
+      Flux<Task> tasks = taskService.getPrioritizedTasks();
+      return new ResponseEntity<>(tasks, HttpStatus.OK);
+  }
+
+  @GetMapping(path = "/top", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Mono<Task>> getTopTask() {
+      Mono<Task> tasks = taskService.getPrioritizedTasks().next();
+      return new ResponseEntity<>(tasks, HttpStatus.OK);
+  }
+
+  @GetMapping(path = "/list", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Mono<Page<Task>>> getPaginatedTasks(Pageable pageable) {
+      Mono<Page<Task>> tasks = taskService.getPaginatedTasks(pageable)
+              .collectList().zipWith(taskService.getTaskCount())
+              .map(p -> new PageImpl<>(p.getT1(), pageable, p.getT2()));
     return new ResponseEntity<>(tasks, HttpStatus.OK);
   }
 

--- a/task-services/src/main/java/com/taat/taskservices/repository/TaskRepository.java
+++ b/task-services/src/main/java/com/taat/taskservices/repository/TaskRepository.java
@@ -1,10 +1,17 @@
 package com.taat.taskservices.repository;
 
 import com.taat.taskservices.model.Task;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TaskRepository extends ReactiveMongoRepository<Task, String> {
+    Flux<Task> findAllBy(Pageable pageable);
 
+    Mono<Long> count();
 }

--- a/task-services/src/main/java/com/taat/taskservices/services/TaskService.java
+++ b/task-services/src/main/java/com/taat/taskservices/services/TaskService.java
@@ -1,12 +1,13 @@
 package com.taat.taskservices.services;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -31,6 +32,16 @@ public class TaskService {
     public Flux<Task> getPrioritizedTasks() {
         Sort priority = Sort.by(Sort.Direction.DESC, "priority");
         return taskRepository.findAll(priority);
+    }
+
+    public Flux<Task> getPaginatedTasks(Pageable pageable) {
+        Sort priority = Sort.by(Sort.Direction.DESC, "priority");
+        Pageable defaultSortingPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), priority);
+        return taskRepository.findAllBy(defaultSortingPageable);
+    }
+
+    public Mono<Long> getTaskCount() {
+        return taskRepository.count();
     }
 
     public Flux<Task> createUpdateTasks(final List<Task> tasks) {

--- a/task-services/src/test/java/com/taat/taskservices/controllers/TaskControllerTest.java
+++ b/task-services/src/test/java/com/taat/taskservices/controllers/TaskControllerTest.java
@@ -1,0 +1,85 @@
+package com.taat.taskservices.controllers;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+
+import com.taat.taskservices.model.Task;
+import com.taat.taskservices.services.TaskService;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskControllerTest {
+
+    @Mock
+    TaskService taskService;
+
+    @InjectMocks
+    TaskController taskController;
+
+    @Test
+    public void testGetTasks() {
+        ResponseEntity<Flux<Task>> results = taskController.getTasks();
+        Assertions.assertNotNull(results);
+    }
+
+    @Test
+    public void testGetTopTask() {
+        Flux<Task> taskFlux = Flux.fromIterable(getTestTasks());
+        Mockito.when(taskService.getPrioritizedTasks()).thenReturn(taskFlux);
+        ResponseEntity<Mono<Task>> results = taskController.getTopTask();
+        Assertions.assertNotNull(results);
+    }
+
+    @Test
+    public void testGetPaginatedTasks() {
+        Flux<Task> taskFlux = Flux.fromIterable(getTestTasks());
+        Mono<Long> taskCount = Mono.just(5l);
+        Mockito.when(taskService.getPaginatedTasks(Mockito.any(Pageable.class))).thenReturn(taskFlux);
+        Mockito.when(taskService.getTaskCount()).thenReturn(taskCount);
+
+        Pageable testPageable = PageRequest.of(0, 5, Sort.unsorted());
+        ResponseEntity<Mono<Page<Task>>> results = taskController.getPaginatedTasks(testPageable);
+        Assertions.assertNotNull(results);
+    }
+
+    private List<Task> getTestTasks() {
+        List<Task> taskList = new ArrayList<>();
+        String currentDateString = LocalDateTime.now().toString().split("T")[0];
+        String previousDateString = LocalDateTime.now().minusDays(1l).toString().split("T")[0];
+        String futureDateString = LocalDateTime.now().plusDays(1l).toString().split("T")[0];
+        taskList.add(
+                new Task("1", "testOwner", "Test Task 1", "A task for testing", null, null,
+                        currentDateString + "T09:45:00", 5, false, false));
+        taskList.add(
+                new Task("2", "testOwner", "Test Task 2", "A task for testing", null, null,
+                        currentDateString + "T09:30:00", 5, false, false));
+        taskList.add(
+                new Task("3", "testOwner", "Test Task 3", "A task with a null due date", null, null,
+                        null, 5, false, false));
+        taskList.add(
+                new Task("4", "testOwner", "Test Task 4", "A task that was due yesterday", null, null,
+                        previousDateString + "T09:15:00", 5, false, false));
+        taskList.add(
+                new Task("5", "testOwner", "Test Task 5", "A task that is due tomorrow", null, null,
+                        futureDateString + "T14:15:00", 5, false, false));
+
+        return taskList;
+    }
+
+}

--- a/task-services/src/test/java/com/taat/taskservices/services/TaskServiceTest.java
+++ b/task-services/src/test/java/com/taat/taskservices/services/TaskServiceTest.java
@@ -11,6 +11,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
 import com.taat.taskservices.model.Task;
@@ -50,6 +52,23 @@ public class TaskServiceTest {
         Flux<Task> results = taskService.getPrioritizedTasks();
         Assertions.assertNotNull(results);
         Mockito.verify(taskRepo, Mockito.times(1)).findAll(Mockito.any(Sort.class));
+    }
+
+    @Test
+    public void testGetPaginatedTasks() {
+        Flux<Task> taskFlux = Flux.fromIterable(getTestTasks());
+        Mockito.when(taskRepo.findAllBy(Mockito.any(Pageable.class))).thenReturn(taskFlux);
+
+        Pageable testPageable = PageRequest.of(0, 5, Sort.unsorted());
+        Flux<Task> results = taskService.getPaginatedTasks(testPageable);
+        Assertions.assertNotNull(results);
+        Mockito.verify(taskRepo, Mockito.times(1)).findAllBy(Mockito.any(Pageable.class));
+    }
+
+    @Test
+    public void testGetTaskCount() {
+        Mockito.when(taskRepo.count()).thenReturn(Mono.just(5l));
+        taskService.getTaskCount().subscribe(countValue -> Assertions.assertEquals(countValue, 5l));
     }
 
     @Test

--- a/web-app/src/App.js
+++ b/web-app/src/App.js
@@ -4,12 +4,12 @@ import './Style.css';
 import logo from './img/logo.svg';
 import { ReactComponent as SVGSingle } from './img/single.svg';
 import { ReactComponent as SVGMulti } from './img/multi.svg';
-import { TASK_API_URL } from './URLConstants';
+import { TASK_API_URL, ALL_TASKS_API_URL } from './URLConstants';
 import { ReactComponent as SVGAdd } from './img/add.svg';
 
 function App() {
-   const [owner, setOwner] = useState('');
- const [createdDate, setCreatedDate] = useState('');
+  const [owner, setOwner] = useState('');
+  const [createdDate, setCreatedDate] = useState('');
 
   const [isThreeColumns, setIsThreeColumns] = useState(false);
   const [items, setItems] = useState([]);
@@ -25,7 +25,7 @@ function App() {
 
   useEffect(() => {
     try {
-      axios.get(TASK_API_URL).then((res) => {
+        axios.get(ALL_TASKS_API_URL).then((res) => {
         setItems(res.data);
       });
     } catch (e) {

--- a/web-app/src/URLConstants.js
+++ b/web-app/src/URLConstants.js
@@ -13,6 +13,13 @@ export const TASK_SVC_URL = getTaskServiceUrl();
 
 export const TASK_API_URL = TASK_SVC_URL + "/api/tasks";
 
+export const ALL_TASKS_API_URL = TASK_API_URL + "/all";
+
+// Example parameters: page=0&size=50&sort=priority,DESC'
+export const PAGINATED_TASKS_API_URL = TASK_API_URL + "/list";
+
+export const TOP_TASK_API_URL = TASK_API_URL + "/top";
+
 export const USER_CALENDAR_API_URL = TASK_SVC_URL + "/api/calendar";
 
 export const USER_CALENDAR_SAVED_API_URL = TASK_SVC_URL + "/api/calendarSaved";


### PR DESCRIPTION
- Updates GET endpoint currently used to populate all UI views to `/api/tasks/all` (will eventually be removed)
- Exposes GET `/api/tasks/top` endpoint for the top task (by descending priority order)
- Exposes GET `/api/tasks/list?page=X&size=Y` endpoint for paginated task list (currently only sorting by descending priority)

Funtionality to filter by user ID and sort by unique priority order will be addressed in a later story
